### PR TITLE
Extract env variables from typedefs for yeoman generator

### DIFF
--- a/src/gh-repos.ts
+++ b/src/gh-repos.ts
@@ -288,7 +288,7 @@ export default class GitHubRepositoriesProvider {
 					param.default = yoType?.[1] || "";
 					param.type = yoType[0];
 
-					param["env"] = descripArray?.[1]?.replace(/(.*)env:/, "") as string;
+					param.env = descripArray?.[1]?.replace(/(.*)env:/, "") as string;
 					arr.push(param);
 				});
 				returnObject.params = arr;

--- a/src/gh-repos.ts
+++ b/src/gh-repos.ts
@@ -277,15 +277,17 @@ export default class GitHubRepositoriesProvider {
 						type: "",
 						description: "",
 						name: "",
-						optional: false,
+						default: "",
 					};
+					const yoType = yoTypeRegex.test(property.type.names.find((name: string) => name.includes("yo")))
+						? yoTypeRegex.exec(property.type.names.find((name: string) => name.includes("yo")))[0].split(":")
+						: ["input"];
 					param.name = property.name as string;
 					const descripArray = property.description.split("=>");
 					param.description = descripArray[0] as string;
-					param.optional = property.optional as boolean;
-					param.type = yoTypeRegex.test(property.type.names.find((name: string) => name.includes("yo")))
-						? yoTypeRegex.exec(property.type.names.find((name: string) => name.includes("yo")))[0]
-						: "input";
+					param.default = yoType?.[1] || "";
+					param.type = yoType[0];
+
 					param["env"] = descripArray?.[1]?.replace(/(.*)env:/, "") as string;
 					arr.push(param);
 				});

--- a/src/gh-repos.ts
+++ b/src/gh-repos.ts
@@ -286,7 +286,7 @@ export default class GitHubRepositoriesProvider {
 					param.type = yoTypeRegex.test(property.type.names.find((name: string) => name.includes("yo")))
 						? yoTypeRegex.exec(property.type.names.find((name: string) => name.includes("yo")))[0]
 						: "input";
-					param["env"] = descripArray?.[2]?.replace(/(.*)env:/, "") as string;
+					param["env"] = descripArray?.[1]?.replace(/(.*)env:/, "") as string;
 					arr.push(param);
 				});
 				returnObject.params = arr;

--- a/src/gh-repos.ts
+++ b/src/gh-repos.ts
@@ -280,11 +280,13 @@ export default class GitHubRepositoriesProvider {
 						optional: false,
 					};
 					param.name = property.name as string;
-					param.description = property.description as string;
+					const descripArray = property.description.split("=>");
+					param.description = descripArray[0] as string;
 					param.optional = property.optional as boolean;
 					param.type = yoTypeRegex.test(property.type.names.find((name: string) => name.includes("yo")))
 						? yoTypeRegex.exec(property.type.names.find((name: string) => name.includes("yo")))[0]
 						: "input";
+					param["env"] = descripArray?.[2]?.replace(/(.*)env:/, "") as string;
 					arr.push(param);
 				});
 				returnObject.params = arr;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -113,7 +113,7 @@ export interface Params {
 	type: string;
 	description: string;
 	name: string;
-	optional?: boolean;
+	default?: string | boolean;
 	env?: string;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -113,7 +113,8 @@ export interface Params {
 	type: string;
 	description: string;
 	name: string;
-	optional: boolean;
+	optional?: boolean;
+	env?: string;
 }
 
 export interface UI5Yaml {


### PR DESCRIPTION
I've added env variable names to the typedef so we can read it from JSDoc in the yeoman generator