### PR TITLE
docs: Typo in references to sources.json

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_package.md
+++ b/.github/ISSUE_TEMPLATE/new_package.md
@@ -17,7 +17,7 @@ Please make sure you meet these requirements first:
 
 ## Pull Request
 
-After checking the prerequisites, you can create a pull request, to edit [`source.json`](https://github.com/ui5-community/bestofui5-website/blob/main/packages/crawler/sources.json) with the following content:
+After checking the prerequisites, you can create a pull request, to edit [`sources.json`](https://github.com/ui5-community/bestofui5-data/blob/main/sources.json) with the following content:
 
 For example, if you want to add the module `https://github.com/ui5-community/ui5-cc-md`, your commit would look like this:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just create a [issue with this template in the `bestofui5-data repo`](https://gi
 ## Description
 
 The crawler is written in Typescript and will get the latest data every day with a GitHub action worklow.  
-It will look at every package defined in the [`source.json`](https://github.com/ui5-community/bestofui5-data/blob/main/sources.json) file.  
+It will look at every package defined in the [`sources.json`](https://github.com/ui5-community/bestofui5-data/blob/main/sources.json) file.
 Currently it´s looking at data from GitHub and NPM.  
 If you´re looking for the latest data files, they are in the `live-data` branch and in the [`data`](https://github.com/ui5-community/bestofui5-data/tree/live-data/data) folder.  
 


### PR DESCRIPTION
Multiple references to `source.json` rather than `sources.json`.