### PR TITLE
feat: add new package @ui5/middleware-code-coverage

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -581,5 +581,19 @@
     "type": "command",
     "tags": ["development", "tooling", "testing", "browser"],
     "license": "mit"
+  },
+    {
+    "owner": "SAP",
+    "repo": "ui5-tooling-extensions",
+    "subpath": "packages",
+    "subpackages": [
+      {
+        "name": "@ui5/middleware-code-coverage",
+        "addedToBoUI5": "2023-03-22T14:12:29.389Z",
+        "type": "middleware",
+        "tags": ["development", "testing", "tooling", "SAP"],
+        "license": "apache-2.0"
+      }
+    ]
   }
 ]

--- a/sources.json
+++ b/sources.json
@@ -588,8 +588,8 @@
     "subpath": "packages",
     "subpackages": [
       {
-        "name": "@ui5/middleware-code-coverage",
-        "addedToBoUI5": "2023-03-22T14:12:29.389Z",
+        "name": "middleware-code-coverage",
+        "addedToBoUI5": "2023-04-20T12:00:00.000Z",
         "type": "middleware",
         "tags": ["development", "testing", "tooling", "SAP"],
         "license": "apache-2.0"


### PR DESCRIPTION
Adds new UI5 middleware to provide client side code coverage determination.

Wait for submitting this PR until UI5 Version 1.113 is released, so the middleware can be actually used.