### PR TITLE
feat: wdio-qunit-service

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -733,5 +733,13 @@
     "type": "command",
     "tags": ["linting", "development", "UI5 2.0", "SAP"],
     "license": "apache-2.0"
+  },
+  {
+    "owner": "mauriciolauffer",
+    "repo": "wdio-qunit-service",
+    "addedToBoUI5": "2024-11-27T00:12:33.328Z",
+    "type": "module",
+    "tags": ["testing", "development", "wdio", "wdi5", "qunit", "karma", "tooling", "browser"],
+    "license": "MIT"
   }
 ]


### PR DESCRIPTION
[WDIO QUnit Service](https://www.npmjs.com/package/wdio-qunit-service) is a drop-in replacement for those using [Karma JS](https://karma-runner.github.io/latest/index.html) to run their QUnit tests ([karma-qunit](https://github.com/karma-runner/karma-qunit/), [karma-ui5](https://github.com/SAP/karma-ui5) or any other combination of Karma and QUnit).